### PR TITLE
优化 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,32 @@
-FROM centos:7
+FROM python:3.6-slim-buster
 # 设置编码
 ENV LANG en_US.UTF-8
 # 同步时间
 ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-# 1. 安装基本依赖
-RUN yum update -y && yum install epel-release -y && yum update -y && yum install wget unzip epel-release nginx  xz gcc automake zlib-devel openssl-devel supervisor  groupinstall development  libxslt-devel libxml2-devel libcurl-devel git -y
-#WORKDIR /var/www/
+# 1. 安装基础环境
+RUN apt update &&\
+    apt install -y --no-install-recommends \
+      supervisor \
+      nginx \
+      git \
+    && rm -rf /var/lib/apt/lists/*
 
-# 2. 准备python
-RUN wget https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tar.xz
-RUN xz -d Python-3.6.6.tar.xz && tar xvf Python-3.6.6.tar && cd Python-3.6.6 && ./configure && make && make install
+# 2. 安装 python 依赖
+RUN pip3 install --no-cache-dir -U git+https://github.com/ss1917/ops_sdk.git
+COPY doc/requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
 
-# 3. 安装websdk
-RUN pip3 install --upgrade pip
-RUN pip3 install -U git+https://github.com/ss1917/ops_sdk.git
-
-# 4. 复制代码
+# 3. 复制代码
 RUN mkdir -p /var/www/
 ADD . /var/www/codo-tools/
 
-# 5. 安装pip依赖
-RUN pip3 install -r /var/www/codo-tools/doc/requirements.txt
 
-# 6. 日志
+# 4. 日志
 VOLUME /var/log/
 
-# 7. 准备文件
+# 5. 准备文件
 COPY doc/nginx_ops.conf /etc/nginx/conf.d/default.conf
 COPY doc/supervisor_ops.conf  /etc/supervisord.conf
 


### PR DESCRIPTION
1. 使用 python image 作为 base image, 减少安装 python 的时间.
2. 独立 python requirements.txt 安装, 减少重复安装 requirements.txt
次数.
3. 清除 ngin 和 supervisor 的安装缓存减少, 镜像大小.